### PR TITLE
Added a 'ignoreFailures' option to disable task reporting on failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ slack {
 }
 ```
 
-By default, everytime a build fails a slack message will be sent to the channel you configured. If a build succeeds nothing happens.
+By default, everytime a build fails a slack message will be sent to the channel you configured (set `ignoreFailures = true` to override it). If a build succeeds nothing happens.
 
 There are more optional fields that enable you to configure the slack integration:
 
@@ -57,6 +57,7 @@ slack {
     dependsOnTasks 'testDebug', 'publishApkRelease'
     title 'my app name'
     enabled = isCDMachine()
+    ignoreFailures = false
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 group = 'com.github.Mindera'
-version = '1.0.7'
+version = '1.0.8-SNAPSHOT'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 

--- a/src/main/groovy/com/mindera/gradle/slack/SlackPlugin.groovy
+++ b/src/main/groovy/com/mindera/gradle/slack/SlackPlugin.groovy
@@ -52,7 +52,7 @@ class SlackPlugin implements Plugin<Project> {
 
     void handleTaskFinished(Task task, TaskState state) {
         Throwable failure = state.getFailure()
-        boolean shouldSendMessage = failure != null || shouldMonitorTask(task);
+        boolean shouldSendMessage = (failure != null && !mExtension.ignoreFailures) || shouldMonitorTask(task);
 
         // only send a slack message if the task failed
         // or the task is registered to be monitored

--- a/src/main/groovy/com/mindera/gradle/slack/SlackPluginExtension.groovy
+++ b/src/main/groovy/com/mindera/gradle/slack/SlackPluginExtension.groovy
@@ -7,6 +7,7 @@ class SlackPluginExtension {
     List<Object> dependsOnTasks
     String title
     boolean enabled = true
+    boolean ignoreFailures = false
 
     void dependsOnTasks(Object... paths) {
         this.dependsOnTasks = Arrays.asList(paths)


### PR DESCRIPTION
The motivation is that I already covered this on my CI server. I use this plugin to provide a notification for certain tasks only.